### PR TITLE
Accepts content_type kwarg for the json_view decorator.

### DIFF
--- a/jsonview/tests.py
+++ b/jsonview/tests.py
@@ -153,3 +153,16 @@ class JsonViewTests(TestCase):
         eq_(404, res.status_code)
         data = json.loads(res.content.decode("utf-8"))
         assert '\xe7\xe9' in data['message']
+
+    def test_override_content_type(self):
+        testtype = "application/vnd.helloworld+json"
+        data = {"foo": "bar"}
+
+        @json_view(content_type=testtype)
+        def temp(req):
+            return data
+
+        res = temp(rf.get('/'))
+        eq_(200, res.status_code)
+        eq_(data, json.loads(res.content.decode("utf-8")))
+        eq_(testtype, res['content-type'])


### PR DESCRIPTION
I want to use more specific content-types than `application/json`, things like `application/vnd.com.myservice.v2+json`. I could just override it in the return values of the functions, but I think specifying it as a decorator parameter would be nice. It's a huge diff but if you ignore whitespaces changes caused by one extra level of indentation, it was a tiny change. I had to change line breaks in a few places just keep flake8 happy about the line length.
