### PR TITLE
Make Python 3 compatibility easier to discover.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,10 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )


### PR DESCRIPTION
Add appropriate Python classifiers so it's easier to discover as a Python 3 compatible application. Django Packages, for example, uses trove classifiers to determine if a package is Python 3 friendly. :-)
