### PR TITLE
Email admins with the full 500 email

### DIFF
--- a/jsonview/decorators.py
+++ b/jsonview/decorators.py
@@ -131,8 +131,7 @@ def json_view(*args, **kwargs):
                 
                 # Generate the usual 500 error email with stack trace and full
                 # debugging information
-                logger.error('Internal Server Error: %s', request.path,
-                    exc_info=e,
+                logger.exception('Internal Server Error: %s', request.path,
                     extra={
                         'status_code': 500,
                         'request': request


### PR DESCRIPTION
Fixes the lack of debugging information from the custom error email generated by jsonview.

This fix generates the normal error email Django sends when a 500 occurs, which includes:
- Path of request
- Additional request meta information (GET, POST, META, etc)

These make the exceptions easier to debug.

![jsonview](https://cloud.githubusercontent.com/assets/59689/3623230/9239e426-0e49-11e4-9dd6-38d4481fc0a1.png)
