### PR TITLE
respect DEBUG_PROPAGATE_EXCEPTIONS

### DIFF
--- a/jsonview/decorators.py
+++ b/jsonview/decorators.py
@@ -124,6 +124,8 @@ def json_view(*args, **kwargs):
                 })
                 return http.HttpResponseBadRequest(blob, content_type=JSON)
             except Exception as e:
+                if settings.DEBUG_PROPAGATE_EXCEPTIONS:
+                    raise
                 if settings.DEBUG:
                     exc_text = unicode(e)
                 else:

--- a/jsonview/tests.py
+++ b/jsonview/tests.py
@@ -144,6 +144,14 @@ class JsonViewTests(TestCase):
         eq_(500, data['error'])
         eq_('An error occurred', data['message'])
 
+    @override_settings(DEBUG_PROPAGATE_EXCEPTIONS=True)
+    def test_server_error_propagate_exception(self):
+        @json_view
+        def temp(req):
+            raise TypeError('fail')
+
+        self.assertRaises(TypeError, temp, rf.get('/'))
+
     def test_http_status(self):
         @json_view
         def temp(req):


### PR DESCRIPTION
I love `DEBUG_PROPAGE_EXCEPTIONS` in my local settings when doing development. If an error occurs in an AJAX request, the only way to find out what the message was is to use the web console (if you have request logging enabled) and look at the output in JSON. 

This setting is built-in since 1.3 series I think and it's still in the [latest master](https://github.com/django/django/blob/524e71c9c20da57722b22b978d87690379ca4ade/django/core/handlers/base.py#L233).
