### PR TITLE
Add additional json.dumps() arguments via JSON_OPTIONS setting

### DIFF
--- a/jsonview/decorators.py
+++ b/jsonview/decorators.py
@@ -35,7 +35,7 @@ def _dump_json(data):
     if getattr(settings, 'JSON_USE_DJANGO_SERIALIZER', True):
         options['cls'] = DjangoJSONEncoder
     else:
-        if 'cls' in options and isinstance(options['cls'], basestring):
+        if 'cls' in options and type(options['cls']) in (str, unicode):
             try:
                 from django.utils.module_loading import import_string
             except ImportError:

--- a/jsonview/decorators.py
+++ b/jsonview/decorators.py
@@ -30,9 +30,23 @@ logger.info('Using %s JSON module.', json.__name__)
 
 
 def _dump_json(data):
+    options = getattr(settings, 'JSON_OPTIONS', {})
+
     if getattr(settings, 'JSON_USE_DJANGO_SERIALIZER', True):
-        return json.dumps(data, cls=DjangoJSONEncoder)
-    return json.dumps(data)
+        options['cls'] = DjangoJSONEncoder
+    else:
+        if 'cls' in options and isinstance(options['cls'], basestring):
+            try:
+                from django.utils.module_loading import import_string
+            except ImportError:
+                raise NotImplementedError(
+                    'Passing custom JSON serializers as strings '
+                    'requires Django 1.7 or greater'
+                )
+            else:
+                options['cls'] = import_string(options['cls'])
+
+    return json.dumps(data, **options)
 
 
 def json_view(*args, **kwargs):

--- a/jsonview/tests.py
+++ b/jsonview/tests.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import json
 import sys
 
-from django import http
+from django import VERSION as django_version, http
 from django.core.exceptions import PermissionDenied
 from django.core.serializers.json import DjangoJSONEncoder
 from django.test import RequestFactory, TestCase
@@ -260,6 +260,13 @@ class JsonViewTests(TestCase):
         def temp(req):
             return {'foo': O()}
 
-        res = temp(rf.get('/'))
-        eq_(200, res.status_code)
-        eq_(payload, res.content)
+        if django_version[0] < 1 or django_version[1] < 7:
+            try:
+                res = temp(rf.get('/'))
+            except NotImplementedError:
+                res = None
+            eq_(res, None)
+        else:
+            res = temp(rf.get('/'))
+            eq_(200, res.status_code)
+            eq_(payload, res.content)


### PR DESCRIPTION
I implemented the JSON_OPTIONS settings we discussed back in February. If you like what you see I can add a Readme update.