### PR TITLE
Change default Content-Type value via Django settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -244,6 +244,12 @@ kwarg**, such as ujson, set the ``cls`` option to ``None``::
         'cls': None,
     }
 
+Default value of content-type is 'application/json'. You can change it vie the
+``JSON_DEFAULT_CONTENT_TYPE`` Django settings. For example, to add
+charset::
+
+   JSON_DEFAULT_CONTENT_TYPE = 'application/json; charset=utf-8'
+
 
 Atomic Requests
 ===============

--- a/jsonview/decorators.py
+++ b/jsonview/decorators.py
@@ -17,7 +17,7 @@ from django.utils.module_loading import import_string
 from .exceptions import BadRequest
 
 json = import_module(getattr(settings, 'JSON_MODULE', 'json'))
-JSON = 'application/json'
+JSON = getattr(settings, 'JSON_DEFAULT_CONTENT_TYPE', 'application/json')
 logger = logging.getLogger('django.request')
 
 


### PR DESCRIPTION
My language is russian. 

If use `ensure_ascii = False` we need in HTTP header 
``Content-type: application/json; charset=UTF-8``

Thanks.