### PR TITLE
Do not change global settings during runtime

### DIFF
--- a/jsonview/decorators.py
+++ b/jsonview/decorators.py
@@ -22,7 +22,8 @@ logger = logging.getLogger('django.request')
 
 
 def _dump_json(data):
-    options = getattr(settings, 'JSON_OPTIONS', {})
+    options = {}
+    options.update(getattr(settings, 'JSON_OPTIONS', {}))
 
     # Use the DjangoJSONEncoder by default, unless cls is set to None.
     options.setdefault('cls', DjangoJSONEncoder)

--- a/jsonview/tests.py
+++ b/jsonview/tests.py
@@ -250,6 +250,13 @@ class JsonViewTests(TestCase):
         payload = json.loads(res.content.decode('utf-8'))
         eq_(500, payload['error'])
 
+        # calling this a second time should still generate a 500 and not
+        # use the `DjangoJSONEncoder`
+        res = temp(rf.get('/'))
+        eq_(500, res.status_code)
+        payload = json.loads(res.content.decode('utf-8'))
+        eq_(500, payload['error'])
+
     @override_settings(
         JSON_OPTIONS={'cls': 'jsonview.tests.CustomTestEncoder'})
     def test_json_custom_serializer_string(self):


### PR DESCRIPTION
The current implementation changes the settings during runtime with `options.pop('cls')` when cls is None.

This breaks usage when you have:

```python
JSON_MODULE = 'ujson'
JSON_OPTIONS = {
    'cls': None
}
```

During the first run you have the correct `{'cls': None}` but during the second you get `{}` which makes `DjangoJSONEncoder` to be used again (which doesn't work with ujson for example).