### PR TITLE
Propagate exception and exc_data via got_request_exception

### DIFF
--- a/jsonview/decorators.py
+++ b/jsonview/decorators.py
@@ -153,9 +153,15 @@ def json_view(*args, **kwargs):
                 # the BaseHandler doesn't get to send this signal. It sets the
                 # sender argument to self.__class__, in case the BaseHandler
                 # is subclassed.
-                got_request_exception.send(sender=BaseHandler, request=request)
+                got_request_exception.send(
+                    sender=BaseHandler,
+                    request=request,
+                    exception=e,
+                    exc_data=exc_data
+                )
                 return http.HttpResponseServerError(blob, content_type=JSON)
         return _wrapped
+
     if len(args) == 1 and callable(args[0]):
         return decorator(args[0])
     else:


### PR DESCRIPTION
It would be nice to have access to the exception and its data in a custom handler, so we could re-raise it and handle it in a custom middleware, e.g.:
```python
from django.core.signals import got_request_exception

def custom_handler(sender, request, **kwargs):
    exc_data = kwargs.get('exc_data')
    
    if exc_data:
        message = exc_data.get('traceback') or exc_data.get('message')
    else:
        message = 'Unknown error'

    exception = kwargs.get('exception')
    error = CustomError(message, cause=exception)

    if exception:
        raise error from exception
    else:
        raise error

got_request_exception.connect(custom_handler)
```

Then:
```python
class CustomExceptionHandler:

    def __init__(self, get_response):
        self.get_response = get_response

    def __call__(self, request):
        return self.get_response(request)

    def process_exception(self, request, exception):
        if isinstance(exception, CustomError):
            # generate custom data structure, e.g.:
            data = {'error_message': exception.message}
            return JsonResponse(data, status=...)
```