### PR TITLE
Python3 django3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,22 @@
 language: python
 sudo: false
 python:
- - "2.7"
  - "3.5"
  - "3.6"
- - "pypy"
+ - "3.7"
+ - "3.8"
  - "pypy3.5"
 env:
- - DJANGO_VERSION=1.11
- - DJANGO_VERSION=2.1
  - DJANGO_VERSION=2.2
+ - DJANGO_VERSION=3.0
 matrix:
   exclude:
-    - python: "2.7"
-      env: DJANGO_VERSION=2.1
-    - python: "2.7"
-      env: DJANGO_VERSION=2.2
-    - python: "pypy"
-      env: DJANGO_VERSION=2.1
-    - python: "pypy"
-      env: DJANGO_VERSION=2.2
+    - python: "3.5"
+      env: DJANGO_VERSION=3.0
+    - python: "pypy3.5"
+      env: DJANGO_VERSION=3.0
 install:
+ - python setup.py install
  - pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99"
  - pip install -q flake8 coverage
 script:

--- a/jsonview/decorators.py
+++ b/jsonview/decorators.py
@@ -11,7 +11,6 @@ from django.core.exceptions import PermissionDenied
 from django.core.handlers.base import BaseHandler
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.signals import got_request_exception
-from django.utils import six
 from django.utils.module_loading import import_string
 
 from .exceptions import BadRequest
@@ -27,7 +26,7 @@ def _dump_json(data):
 
     # Use the DjangoJSONEncoder by default, unless cls is set to None.
     options.setdefault('cls', DjangoJSONEncoder)
-    if isinstance(options['cls'], six.string_types):
+    if isinstance(options['cls'], str):
         options['cls'] = import_string(options['cls'])
     elif options['cls'] is None:
         options.pop('cls')
@@ -101,7 +100,7 @@ def json_view(*args, **kwargs):
             except http.Http404 as e:
                 blob = _dump_json({
                     'error': 404,
-                    'message': six.text_type(e),
+                    'message': str(e),
                 })
                 logger.warning('Not found: %s', request.path,
                                extra={
@@ -118,13 +117,13 @@ def json_view(*args, **kwargs):
                     })
                 blob = _dump_json({
                     'error': 403,
-                    'message': six.text_type(e),
+                    'message': str(e),
                 })
                 return http.HttpResponseForbidden(blob, content_type=JSON)
             except BadRequest as e:
                 blob = _dump_json({
                     'error': 400,
-                    'message': six.text_type(e),
+                    'message': str(e),
                 })
                 return http.HttpResponseBadRequest(blob, content_type=JSON)
             except Exception as e:
@@ -133,7 +132,7 @@ def json_view(*args, **kwargs):
                     'message': 'An error occurred',
                 }
                 if settings.DEBUG:
-                    exc_data['message'] = six.text_type(e)
+                    exc_data['message'] = str(e)
                     exc_data['traceback'] = traceback.format_exc()
 
                 blob = _dump_json(exc_data)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setup(
     include_package_data=True,
     package_data={'': ['README.rst']},
     zip_safe=False,
+    install_requires=["django>=2.0.0"],
+    tests_require=["coverage"],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
1. Python 2 support removed
1. Only django 1.11, 2.2 and 3.0 are currently under active support (and 1.11 is for python2) so only testing on 2.2 and 3.0
1. six usage and version checks removed